### PR TITLE
Sequence summary service for ModelArchive

### DIFF
--- a/resources/registry.json
+++ b/resources/registry.json
@@ -190,6 +190,11 @@
             "serviceType": "sequence",
             "provider": "swissmodel",
             "accessPoint": "sequence/summary/"
+        },
+        {
+            "serviceType": "sequence",
+            "provider": "modelarchive",
+            "accessPoint": "sequence/summary/"
         }
     ]
 }


### PR DESCRIPTION
This pull request adds a new service provider entry to the `resources/registry.json` file. The change introduces the `modelarchive` provider with the same service type and access point as the existing `swissmodel` provider.