### PR TITLE
Fixed PDBe service URLs

### DIFF
--- a/resources/registry.json
+++ b/resources/registry.json
@@ -118,12 +118,12 @@
         {
             "serviceType": "uniprot",
             "provider": "pdbe",
-            "accessPoint": "uniprot/"
+            "accessPoint": "beacons/uniprot/"
         },
         {
             "serviceType": "summary",
             "provider": "pdbe",
-            "accessPoint": "uniprot/summary/"
+            "accessPoint": "beacons/uniprot/summary/"
         },
         {
             "serviceType": "summary",
@@ -169,7 +169,7 @@
         {
             "serviceType": "annotations",
             "provider": "pdbe",
-            "accessPoint": "annotations/"
+            "accessPoint": "beacons/annotations/"
         },
         {
             "serviceType": "summary",


### PR DESCRIPTION
This pull request updates the `resources/registry.json` file to modify the access points for several services provided by `pdbe`. The changes ensure that all access points now use the `beacons` prefix, aligning with a standardized naming convention.

Access point updates:

* Updated the `accessPoint` for the `uniprot` service to `beacons/uniprot/`. (`[resources/registry.jsonL121-R126](diffhunk://#diff-fdd67012558c3c7fc77081b9c9392498590e8d24c44ddbb6bd2a5742394d51adL121-R126)`)
* Updated the `accessPoint` for the `summary` service to `beacons/uniprot/summary/`. (`[resources/registry.jsonL121-R126](diffhunk://#diff-fdd67012558c3c7fc77081b9c9392498590e8d24c44ddbb6bd2a5742394d51adL121-R126)`)
* Updated the `accessPoint` for the `annotations` service to `beacons/annotations/`. (`[resources/registry.jsonL172-R172](diffhunk://#diff-fdd67012558c3c7fc77081b9c9392498590e8d24c44ddbb6bd2a5742394d51adL172-R172)`)