### PR TITLE
Fixed PDBe service URLs

### DIFF
--- a/resources/registry.json
+++ b/resources/registry.json
@@ -118,12 +118,12 @@
         {
             "serviceType": "uniprot",
             "provider": "pdbe",
-            "accessPoint": "uniprot/"
+            "accessPoint": "beacons/uniprot/"
         },
         {
             "serviceType": "summary",
             "provider": "pdbe",
-            "accessPoint": "uniprot/summary/"
+            "accessPoint": "beacons/uniprot/summary/"
         },
         {
             "serviceType": "summary",
@@ -169,7 +169,7 @@
         {
             "serviceType": "annotations",
             "provider": "pdbe",
-            "accessPoint": "annotations/"
+            "accessPoint": "beacons/annotations/"
         },
         {
             "serviceType": "summary",


### PR DESCRIPTION
This pull request updates the `resources/registry.json` file to reflect changes in the access points for several services provided by `pdbe`. The updates standardize the access point paths by prefixing them with `beacons/`.

Access point updates:

* Changed the `accessPoint` for the `uniprot` service from `uniprot/` to `beacons/uniprot/`. (`[resources/registry.jsonL121-R126](diffhunk://#diff-fdd67012558c3c7fc77081b9c9392498590e8d24c44ddbb6bd2a5742394d51adL121-R126)`)
* Changed the `accessPoint` for the `uniprot summary` service from `uniprot/summary/` to `beacons/uniprot/summary/`. (`[resources/registry.jsonL121-R126](diffhunk://#diff-fdd67012558c3c7fc77081b9c9392498590e8d24c44ddbb6bd2a5742394d51adL121-R126)`)
* Changed the `accessPoint` for the `annotations` service from `annotations/` to `beacons/annotations/`. (`[resources/registry.jsonL172-R172](diffhunk://#diff-fdd67012558c3c7fc77081b9c9392498590e8d24c44ddbb6bd2a5742394d51adL172-R172)`)