### PR TITLE
Add annotations service for AlphaFold in registry.json

### DIFF
--- a/resources/registry.json
+++ b/resources/registry.json
@@ -195,6 +195,11 @@
             "serviceType": "sequence",
             "provider": "modelarchive",
             "accessPoint": "sequence/summary/"
+        },
+        {
+            "serviceType": "annotations",
+            "provider": "alphafold",
+            "accessPoint": "annotations/"
         }
     ]
 }


### PR DESCRIPTION
This pull request adds support for a new service type in the `resources/registry.json` file. The change introduces an `annotations` service provided by `alphafold` with its corresponding access point.

Key change:

* [`resources/registry.json`](diffhunk://#diff-fdd67012558c3c7fc77081b9c9392498590e8d24c44ddbb6bd2a5742394d51adR198-R202): Added a new service entry for `annotations` with the provider `alphafold` and the access point `annotations/`.