### PR TITLE
Af annotations

### DIFF
--- a/resources/registry.json
+++ b/resources/registry.json
@@ -195,6 +195,11 @@
             "serviceType": "sequence",
             "provider": "modelarchive",
             "accessPoint": "sequence/summary/"
+        },
+        {
+            "serviceType": "annotations",
+            "provider": "alphafold",
+            "accessPoint": "annotations/"
         }
     ]
 }


### PR DESCRIPTION
This pull request adds a new service entry to the `resources/registry.json` file. The change introduces the `annotations` service type, provided by `alphafold`, with an access point at `annotations/`.